### PR TITLE
Change process kill to process terminate

### DIFF
--- a/src/minizinc/CLI/instance.py
+++ b/src/minizinc/CLI/instance.py
@@ -367,7 +367,7 @@ class CLIInstance(Instance):
                 # Process was reached hard deadline (timeout + 5 sec) or was
                 # cancelled by the user.
                 # Kill process and read remaining output
-                proc.kill()
+                proc.terminate()
                 await proc.wait()
                 remainder = await proc.stdout.read()
 


### PR DESCRIPTION
This allows the CLI to cleanly terminate. Otherwise the child processes  (i.e solver like fzn-gecode) are not killed, just the CLI minizinc process.