### PR TITLE
Ensure files are closed before removing them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ this project adheres to `Semantic Versioning <https://semver.org/>`_.
 Unreleased_
 ------------
 
+Fixed
+^^^^^
+
+- Always close temporary files before removing them, so that if an exception is
+  raised while a file is still open, it gets removed correctly on Windows.
+
 0.4.2_ - 2020-11-25
 -------------------
 

--- a/src/minizinc/CLI/instance.py
+++ b/src/minizinc/CLI/instance.py
@@ -157,6 +157,7 @@ class CLIInstance(Instance):
             yield files
         finally:
             for file in gen_files:
+                file.close()
                 os.remove(file.name)
 
     @property


### PR DESCRIPTION
On Windows an error will occur if the file is open when `os.remove` is called (not sure about other platforms - as far as I remember, this shouldn't be a problem for Unix).

This can happen if the JSON encoder fails and raises an exception as in this example:

```python
from minizinc import Solver, Model, Instance

class NonSerializable:
    pass

model = Model()
model["x"] = NonSerializable()
solver = Solver.lookup("gecode")
instance = Instance(solver, model)
print(instance.solve())
```

Which gives `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\jngu0054\\AppData\\Local\\Temp\\mzn_data6v5pkm7x.json'`, and so the temporary file is not removed.

Closing the file just before removing it fixes the issue.