### PR TITLE
Create processes in their own console on Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Fixed
 
 - Always close temporary files before removing them, so that if an exception is
   raised while a file is still open, it gets removed correctly on Windows.
+- Set the required process creation flags on Windows to allow MiniZinc to
+  terminate its subprocesses correctly.
 
 0.4.2_ - 2020-11-25
 -------------------


### PR DESCRIPTION
This allows MiniZinc to properly interrupt its subprocesses on Windows, and not also the Python process (since signals are per console, currently when `minizinc` times out, it generates a Ctrl+C for its console to terminate the subprocesses and give them a chance to output final solutions/stats - but this has the side effect of also terminating Python which is in the same console).

I'm not fully convinced that `minizinc-python` should actually have to do this, but I don't know any other way for MiniZinc to reliably terminate its subprocesses (without having to put another process in between MiniZinc and the solver, which is apparently what Visual Studio does to manage its subprocesses).