### PR TITLE
Remove hard timeouts from CLI driver

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changed
 ^^^^^^^
 - **BREAKING:** Update minimal supported MiniZinc version to 2.5.0 to ensure
   full functionality.
+- Remove the (additional) hard time-out in from the CLI driver. MiniZinc should
+  correctly enforce set time limit.
 
 Fixed
 ^^^^^

--- a/src/minizinc/CLI/driver.py
+++ b/src/minizinc/CLI/driver.py
@@ -8,7 +8,6 @@ import sys
 import warnings
 from asyncio import create_subprocess_exec
 from asyncio.subprocess import PIPE, Process
-from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Type, Union
 
@@ -101,13 +100,8 @@ class CLIDriver(Driver):
         self,
         args: List[Any],
         solver: Optional[Solver] = None,
-        timeout: Optional[timedelta] = None,
     ):
         # TODO: Add documentation
-        timeout_flt = None
-        if timeout is not None:
-            timeout_flt = timeout.total_seconds()
-
         windows_spawn_options: Dict[str, Any] = {}
         if sys.platform == "win32":
             # On Windows, MiniZinc terminates its subprocesses by generating a
@@ -130,16 +124,12 @@ class CLIDriver(Driver):
             cmd = [str(self._executable), "--allow-multiple-assignments"] + [
                 str(arg) for arg in args
             ]
-            minizinc.logger.debug(
-                f"CLIDriver:run -> command: \"{' '.join(cmd)}\", timeout "
-                f"{timeout_flt}"
-            )
+            minizinc.logger.debug(f"CLIDriver:run -> command: \"{' '.join(cmd)}\"")
             output = subprocess.run(
                 cmd,
                 stdin=None,
                 stdout=PIPE,
                 stderr=PIPE,
-                timeout=timeout_flt,
                 **windows_spawn_options,
             )
         else:
@@ -150,16 +140,12 @@ class CLIDriver(Driver):
                     conf,
                     "--allow-multiple-assignments",
                 ] + [str(arg) for arg in args]
-                minizinc.logger.debug(
-                    f"CLIDriver:run -> command: \"{' '.join(cmd)}\", timeout "
-                    f"{timeout_flt}"
-                )
+                minizinc.logger.debug(f"CLIDriver:run -> command: \"{' '.join(cmd)}\"")
                 output = subprocess.run(
                     cmd,
                     stdin=None,
                     stdout=PIPE,
                     stderr=PIPE,
-                    timeout=timeout_flt,
                     **windows_spawn_options,
                 )
         if output.returncode != 0:

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ deps =
     flake8-bugbear
     isort[pyproject]
     mypy
+    types-dataclasses
+    types-setuptools
 skip_install = true
 commands =
     black docs src tests --check


### PR DESCRIPTION
The MiniZinc compiler now (better) enforces the timeout given as an
argument. Setting our own hard timeout is unnecessary, might be
confusing, and might interfere with post-processing of solutions after
the solver has been stopped.

If a hard-timeout is required, then the user can still use asyncio
timeouts
