### PR TITLE
Handle the incorrect output of "_objective" from grader models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,8 @@ Fixed
   the documentation.
 - Correctly pass the ``-O0`` flag to the CLI when ``optimisation_level`` is set
   to zero.
+- Ignore the ``_objective`` output by MiniZinc when it is not an optimisation
+  problem.
 
 0.4.2_ - 2020-11-25
 -------------------

--- a/src/minizinc/CLI/instance.py
+++ b/src/minizinc/CLI/instance.py
@@ -23,7 +23,7 @@ from minizinc.error import parse_error
 from minizinc.instance import Instance
 from minizinc.json import MZNJSONEncoder
 from minizinc.model import Method, Model, ParPath, UnknownExpression
-from minizinc.result import Result, Status, parse_solution, set_stat
+from minizinc.result import Result, Status, _GeneratedSolution, parse_solution, set_stat
 from minizinc.solver import Solver
 
 from .driver import CLIDriver, to_python_type
@@ -34,10 +34,6 @@ if sys.version_info >= (3, 8):
     SEPARATOR: Final[bytes] = str.encode("----------" + os.linesep)
 else:
     SEPARATOR: bytes = str.encode("----------" + os.linesep)
-
-
-class _GeneratedSolution:
-    pass
 
 
 class CLIInstance(Instance):

--- a/src/minizinc/result.py
+++ b/src/minizinc/result.py
@@ -3,7 +3,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import timedelta
 from enum import Enum, auto
 from json import loads
@@ -79,6 +79,10 @@ StdStatisticTypes = {
     # Number of linear constraints removed through chain compression
     "eliminatedLinearConstraints": int,
 }
+
+
+class _GeneratedSolution:
+    pass
 
 
 def set_stat(stats: Dict[str, StatisticsType], name: str, value: str):
@@ -334,7 +338,13 @@ def parse_solution(
     if b"{" in raw:
         tmp = loads(raw, enum_map=enum_map, cls=MZNJSONDecoder)
         if "_objective" in tmp:
-            tmp["objective"] = tmp.pop("_objective")
+            obj = tmp.pop("_objective")
+            # TODO: Remove this workaround when MiniZinc no longer outputs _objective
+            # in checker models as an objective.
+            if not issubclass(output_type, _GeneratedSolution) or "objective" in {
+                f.name for f in fields(output_type)
+            }:
+                tmp["objective"] = obj
         if "_output" in tmp:
             tmp["_output_item"] = tmp.pop("_output")
         for k in kwlist:


### PR DESCRIPTION
Grader models might inspect the _objective of a model, but by mistake
they also output this value as the objective. This gives an error as the
input is unexpected by the output object.