### PR TITLE
Add explicit ability for Driver objects to report available solvers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,17 +11,23 @@ Unreleased_
 
 Added
 ^^^^^
+
 - Add (generated) ``__version__`` field to the package to abide by the PEP
   recommendations
 - Add support for using NumPy types to instantiate Models. (``np.array`` and
   any type that falls under ``np.generic``)
+- Add ``available_solvers`` method to the ``Driver`` objects to explicitly
+  report the available solvers according to the current environment
 
 Changed
 ^^^^^^^
+
 - **BREAKING:** Update minimal supported MiniZinc version to 2.5.0 to ensure
   full functionality.
 - Remove the (additional) hard time-out in from the CLI driver. MiniZinc should
   correctly enforce set time limit.
+- ``Solver.lookup`` now has an extra ``refresh`` argument to signal whether
+  the driver should refresh the found solver configurations.
 
 Fixed
 ^^^^^

--- a/src/minizinc/driver.py
+++ b/src/minizinc/driver.py
@@ -62,6 +62,25 @@ class Driver(ABC):
         """
         pass
 
+    @abstractmethod
+    def available_solvers(self, refresh=False):
+        """Returns a list of available solvers
+
+        This method returns the list of solvers available to the Driver object
+        according to the current environment. Note that the list of solvers might
+        be cached for future usage. The refresh argument can be used to ignore
+        the current cache.
+
+        Args:
+            refresh (bool): When set to true, the Driver will rediscover the
+                available solvers from the current environment.
+
+        Returns:
+            Dict[str, List[Solver]]: A dictionary that maps solver tags to MiniZinc
+                solver configurations that can be used with the Driver object.
+        """
+        pass
+
 
 def find_driver(
     path: Optional[List[str]] = None, name: str = "minizinc"


### PR DESCRIPTION
This resolvers #32, although maybe not directly how @tias requested.

This PR introduces a `Driver.available_solvers` method that reports on all the available solver. This is however not a simple list, but rather a map from `tags` which includes the `id` to the `Solver` objects.

Issue #32 also considered the use of filtering the solvers, so only currently usable solvers would be reported. Tags might be the correct way to achieve this, but we should introduce better standard tags to actually make this work (Currently using the `int` tag seems to give at least all discrete solvers. It might however not directly solve the problem whether solvers like Gurobi, CPLEX, FICO XPress, or SCIP can be found. When reporting on the solvers we can add a `incomplete` tag when not all information is available or library files are missing