### PR TITLE
fix typo in documentation

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -275,7 +275,7 @@ sets one as the new default.
 
     print(default_driver.minizinc_version)
 
-    v23: Driver = Diver.find(["/minizinc/2.3.2/bin"])
+    v23: Driver = Driver.find(["/minizinc/2.3.2/bin"])
     print(v23.minizinc_version)
     gecode = Solver.lookup("gecode", driver=v23)
     v23_instance = Instance(gecode, driver=v23)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -15,7 +15,7 @@ MiniZinc Python requires the following software to be installed on you machine:
     environmental variable. When MiniZinc cannot be located, the following
     warning will be shown: **MiniZinc was not found on the system: no default
     driver could be initialised**. The path can manually be provided using
-    ``Diver.find`` function.
+    ``Driver.find`` function.
 
 Installation
 ------------


### PR DESCRIPTION
This is just a small fix where `Driver` was misspelled as `Diver` in the documentation.