### PR TITLE
Fix no intermediate solutions for async solutions

### DIFF
--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -90,6 +90,17 @@ class TestMaximise(InstanceTestCase):
         assert len(result) == 21
         assert result.objective == 25
 
+    def test_solutions_no_intermediate(self):
+        async def run():
+            results=[]
+            async for result in self.instance.solutions(intermediate_solutions=False):
+                results.append(result)
+            return results
+            
+        results = asyncio.run(run())
+        assert len(results) == 2
+        assert results[0].solution.objective == 25 and results[1].solution is None
+
 
 class TestParameter(InstanceTestCase):
     code = """

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -98,8 +98,8 @@ class TestMaximise(InstanceTestCase):
             return results
             
         results = asyncio.run(run())
-        assert len(results) == 2
-        assert results[0].solution.objective == 25 and results[1].solution is None
+        assert len(results) == 1
+        assert results[0].solution.objective == 25 
 
 
 class TestParameter(InstanceTestCase):


### PR DESCRIPTION
When intermediate_solutions=False, we should only yield the last solution.