### PR TITLE
Remove set to range optimization

### DIFF
--- a/src/minizinc/json.py
+++ b/src/minizinc/json.py
@@ -57,10 +57,6 @@ class MZNJSONDecoder(JSONDecoder):
     def mzn_object_hook(self, obj):
         if isinstance(obj, dict):
             if len(obj) == 1 and "set" in obj:
-                if len(obj["set"]) == 1 and isinstance(obj["set"][0], list):
-                    assert len(obj["set"][0]) == 2
-                    return range(obj["set"][0][0], obj["set"][0][1] + 1)
-
                 li = []
                 for item in obj["set"]:
                     if isinstance(item, list):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -152,7 +152,7 @@ class TestEnum(InstanceTestCase):
 
 
 class TestSets(InstanceTestCase):
-    def test_ranges(self):
+    def test_sets(self):
         self.instance.add_string(
             """
             var set of 0..10: s;
@@ -163,8 +163,8 @@ class TestSets(InstanceTestCase):
 
         self.instance["s1"] = range(1, 4)
         result = self.instance.solve()
-        assert isinstance(result["s"], range)
-        assert result["s"] == range(1, 4)
+        assert isinstance(result["s"], set)
+        assert result["s"] == set(range(1, 4))
 
 
 class TestString(InstanceTestCase):


### PR DESCRIPTION
Apparently, ruamel cannot easily parse YAML containing python ranges. A better optimization is to make our own RangeList set representation in the future.