### PR TITLE
Accept empty lists on the DZN grammar.

### DIFF
--- a/src/minizinc/dzn.py
+++ b/src/minizinc/dzn.py
@@ -21,7 +21,7 @@ dzn_grammar = r"""
          | string
          | "true"       -> true
          | "false"      -> false
-    list: [value ("," value)* ","?]
+    list: [] | [value ("," value)* ","?]
     array: "[" list "]"
     array2d: "[" "|" [ list ("|" list)*] "|" "]"
     set: "{" list "}"


### PR DESCRIPTION
Before this change, empty lists were wrongly parsed as a list with a singleton Null element.